### PR TITLE
Inheritance bug

### DIFF
--- a/taggit/__init__.py
+++ b/taggit/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 21, 3, 'dev2')
+VERSION = (0, 21, 3, 'dev3')
 
 default_app_config = 'taggit.apps.TaggitAppConfig'

--- a/tests/models.py
+++ b/tests/models.py
@@ -238,7 +238,7 @@ class CustomManager(models.Model):
 
 
 class Parent(models.Model):
-    tags = TaggableManager()
+    tags = TaggableManager(concrete_inherit=True)
 
 
 class Child(Parent):


### PR DESCRIPTION
This PR changes the behavior of TaggedItems that have concrete inheritance. By default, tags appear on the child objects if they're tagged there, but we want them to always route through the parent. The new `concrete_inherit` kwarg sets up that behavior.